### PR TITLE
Fix error when creating an user without associating a group

### DIFF
--- a/app/views/user/participants/_form.html.erb
+++ b/app/views/user/participants/_form.html.erb
@@ -26,13 +26,15 @@
     <%= form.label :birth_date, style: "display: block" %>
     <%= form.date_field :birth_date %>
   </div>
-  <div class="field">
-    <%= form.label :grouping_id %>
-    <%=
+  <% if current_admin.groupings %>
+    <div class="field">
+      <%= form.label :grouping_id %>
+      <%=
       form.select :grouping_id,
       options_from_collection_for_select(current_admin.groupings, :id, :name)
     %>
-  </div>
+    </div>
+  <% end %>
   <div class="field">
     <%= form.label :user_admin_id, style: "display: none" %>
     <%= form.text_field :user_admin_id, value: current_admin.id, style: "display: none" %>

--- a/app/views/user/participants/_participant.html.erb
+++ b/app/views/user/participants/_participant.html.erb
@@ -22,10 +22,10 @@
       <tbody>
         <tr>
           <td class="id-cell">
-            <%= participant.grouping.id %>
+            <%= participant.grouping&.id %>
           </td>
           <td class="name-cell">
-            <%= participant.grouping.name %>
+            <%= participant.grouping&.name %>
           </td>
           <td class="link-cell">
             <%= link_to t("groupings.show"), participant.grouping, class: "text-xs" %>


### PR DESCRIPTION
When a participant was created without associating a group to it, the _participant.html.erb partial was breaking because it was trying to read an `id` and a `name` for a `nil` group.

This PR fix this error using the safe navigation operator, and it hides the group option from the participant form if no groups are created yet.