### PR TITLE
Add user_participant foreign key to answer association

### DIFF
--- a/app/models/user/participant.rb
+++ b/app/models/user/participant.rb
@@ -4,7 +4,7 @@ module User
 
     belongs_to :user_admin, class_name: "User::Admin"
     belongs_to :grouping, optional: true
-    has_many :answers, dependent: :destroy
+    has_many :answers, dependent: :destroy, foreign_key: :user_participant_id
     has_many :rounds
     has_many :reports, through: :rounds
 


### PR DESCRIPTION
An error was occurring when trying to delete a participant because the participant foreign key in the Answer association was wrong.

This PR fix the foreign key used in the `has_many :answers` association. 