### PR TITLE
Fix application title

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="<%= I18n.locale.downcase %>">
   <head>
-    <title><%= content_for(:title) || "S.A.M" %></title>
+    <title><%= content_for(:title) || "S.A.M.Ba" %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <%= csrf_meta_tags %>


### PR DESCRIPTION
After changing the name of the application from `S.A.M. - Math Assessment Software' to `S.A.M.Ba - System for Basic Math Assessment", a spot went unnoticed. This PR aims to correct it.